### PR TITLE
update docs to reflect reality

### DIFF
--- a/SECURITY_WITHBOUNTY.md
+++ b/SECURITY_WITHBOUNTY.md
@@ -43,17 +43,13 @@ We require that all researchers:
 * Make every effort to avoid privacy violations, degradation of user experience,
   disruption to production systems (including but not limited to the Cosmos
   Hub), and destruction of data.
-* Keep any information about vulnerabilities that you’ve discovered confidential
-  between yourself and the Cosmos engineering team until the issue has been
-  resolved and disclosed.
+* Keep any information about vulnerabilities limited to only relevant parties. 
 * Avoid posting personally identifiable information, privately or publicly.
 
 If you follow these guidelines when reporting an issue to us, we commit to:
 
 * Not pursue or support any legal action related to your research on this
   vulnerability
-* Work with you to understand, resolve and ultimately disclose the issue in a
-  timely fashion
 
 ### More information
 


### PR DESCRIPTION
this document did not reflect reality and has been edited to reflect reality.

I surely hope that instead of merging this this particular pull request, we can instead collaborate on:


* https://github.com/cosmos/security/pull/1https://github.com/cosmos/security/pull/19

But I must frankly and strongly state that no matter which PR is chosen by the Interchain Foundation -- both are an improvement on the current state as the current state misleads people who only wish to help.

Of course, it's also misleading that there is a "cosmos engineering team" but I sincerely hope that we go with [this one](https://github.com/cosmos/security/pull/19) instead.