### PR TITLE
remove threats and make optimal

### DIFF
--- a/SECURITY_WITHBOUNTY.md
+++ b/SECURITY_WITHBOUNTY.md
@@ -43,8 +43,7 @@ reproduction steps and details of the issue.
 
 We require that all researchers:
 
-* avoid posting vulnerability information in public places, including GitHub, Discord,
-  Telegram, and Twitter.
+* avoid posting vulnerability information in public places, including public GitHub repositories, public Discords, public Telegram chats, and public Twitter.
 * Make every effort to avoid privacy violations, degradation of user experience,
   disruption to production systems (including but not limited to the Cosmos
   Hub), and destruction of data.

--- a/SECURITY_WITHBOUNTY.md
+++ b/SECURITY_WITHBOUNTY.md
@@ -35,25 +35,21 @@ reproduction steps and details of the issue.
 
 ### Guidelines
 
+**We commit to**
+* Not pursue or support any legal action related to your research on this
+  vulnerability
+* Vigorously support security research that is done in a white-hat fashion, where information is shared with the foundation and relevant parties.  
+
 We require that all researchers:
 
-* Abide by this policy to disclose vulnerabilities, and avoid posting
-  vulnerability information in public places, including GitHub, Discord,
+* avoid posting vulnerability information in public places, including GitHub, Discord,
   Telegram, and Twitter.
 * Make every effort to avoid privacy violations, degradation of user experience,
   disruption to production systems (including but not limited to the Cosmos
   Hub), and destruction of data.
 * Keep any information about vulnerabilities that you’ve discovered confidential
-  between yourself and the Cosmos engineering team until the issue has been
-  resolved and disclosed.
+  between yourself and relevant parties until the issue has been resolved.
 * Avoid posting personally identifiable information, privately or publicly.
-
-If you follow these guidelines when reporting an issue to us, we commit to:
-
-* Not pursue or support any legal action related to your research on this
-  vulnerability
-* Work with you to understand, resolve and ultimately disclose the issue in a
-  timely fashion
 
 ### More information
 

--- a/SECURITY_WITHBOUNTY.md
+++ b/SECURITY_WITHBOUNTY.md
@@ -36,9 +36,10 @@ reproduction steps and details of the issue.
 ### Guidelines
 
 **We commit to**
-* Not pursue or support any legal action related to your research on this
-  vulnerability
-* Vigorously support security research that is done in a white-hat fashion, where information is shared with the foundation and relevant parties.  
+* Not pursue or support any legal action related to your research on this vulnerability, provided that you're minimizing risk.
+* Vigorously support security research that is done in a white-hat fashion, where information is shared with the foundation and relevant parties in a manner that minimizes risk.
+* Communicating with researchers throughout a disclosure process
+* Allowing researchers to review reports before release
 
 We require that all researchers:
 


### PR DESCRIPTION
I don't think that this document, pre-editing, provides protection to researchers or teams building in cosmos.

I also think that there is not a single cosmos team.  I think that our security policies today, as a community, negate the staggering accomplishments that we've made in doing things the right way -- decentralized. 

For example, many security incidents are discovered in the wild.  Some security incidents have already been dutifully reported to the ICF years ago, like [this one](https://forum.cosmos.network/t/amulet-security-advisory-for-cometbft-asa-2023-002/11604)

Many, many researchers and research organizations in Cosmos have contractual relationships with numerous cosmos participants.  The former wording of this document made it impossible to work within its rules if a researcher is, for example, with a validation org that grew into a software engineering org with a security practice, or in fact numerous permutations on this theme, which I am aware compose nearly 100% of relevant organizations who might be making such reports. 

In 2021, when the Notional team [first reported](https://forum.cosmos.network/t/amulet-security-advisory-for-cometbft-asa-2023-002/11604) there was an 18 day turnaround time and in fact no response at all until I personally began to seek out members of the foundation.  No bounty whatsoever was paid and no recognition whatsoever was given. 

In fact, the former wording of this file meant that [this incident](https://forum.cosmos.network/t/amulet-security-advisory-for-cometbft-asa-2023-002/11604)

Had violated these policies from **day zero** (since October 15, 2021), because:

1) "Cosmos engineering team" has no meaning, unless the foundation wishes to state that that is a singular thing which, quite frankly raises very serious questions.
2) [this issue](https://forum.cosmos.network/t/amulet-security-advisory-for-cometbft-asa-2023-002/11604)
  * was discovered by an entire chain's validator set, three times, in production, over the course of years
  * was worked by MANY teams pursuant to the 2023 outbreak of [the incident](https://forum.cosmos.network/t/amulet-security-advisory-for-cometbft-asa-2023-002/11604)  before [Notional](https://notional.ventures) reported it, including but not limited to:
    1) Stride
    2) Informal's Cosmos Hub Team
    3) Skip
    4) Range
    5) Informal's Comet Team
    6) CryptoCrew
    7) Jerry Chang from ICYCro
    8) Notional
    9) the whole sentinel validator set in 2021
    10) the whole luna classic validator set, pre-may-2022 mass abandonment
    10) the whole stride validator set in 2023
3) I was made aware of the 2023 outbreak of [the issue](https://forum.cosmos.network/t/amulet-security-advisory-for-cometbft-asa-2023-002/11604) by a tweet from a fellow validator, who I'd like to praise but don't know if I'd be exposing to legal liability from the interchain foundation or Amulet.  They had no idea that they were discussing an issue that I'd already reported to the foundation, and it should always be fine for a validator to discuss bandwidth consumption.  Of course, I will not be providing their identity.

4) Our team at Notional, as well as some others, encouraged the foundation / amulet to get in touch but this was to no avail.  The degree of hardship caused here is difficult to overstate.

5) not a single one of the teams involved (>100) ever behaved in a byzantine manner to my knowledge.  More teams contributed to analysis than I remember.
    


